### PR TITLE
Unit Tests: MOTD Listing First Draft

### DIFF
--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -54,7 +54,33 @@ describe("listMotds", () => {
     expect(motdsFoundFromListing).toEqual(expect.arrayContaining(allMotds));
   });
 
-  it("returns results in descending order");
+  it("returns results in descending order", async () => {
+    // Create a bunch of dummy MOTDs
+    await Promise.all(
+      faker.helpers
+        .multiple(faker.hacker.phrase, { count: 256 })
+        .map(async (phrase) => createMotd(phrase)),
+    );
+
+    // Paginate through the EVERYTHING, and collect results.
+    const motdsFoundFromListing: MessageOfTheDay[] = [];
+    let lastId: string | undefined;
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const results = await listMotds({ pageSize: 8, previousLastId: lastId });
+
+      results.items.forEach((item) => motdsFoundFromListing.push(item));
+      lastId = results.lastId;
+    } while (lastId);
+
+    // Ensure in correct order
+    for (let i = 0; i < motdsFoundFromListing.length - 1; i += 1) {
+      const thisMotd = motdsFoundFromListing[i];
+      const nextMotd = motdsFoundFromListing[i + 1];
+      expect(thisMotd.createdAt.valueOf()).toBeGreaterThanOrEqual(nextMotd.createdAt.valueOf());
+    }
+  });
+
   it("doesn't exceed pageSize");
 });
 

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -21,8 +21,8 @@ describe("listMotds", () => {
   //
 
   it("excludes pageKey when no results", async () => {
-    const { pageKey } = await listMotds({ pageSize: 8 });
-    expect(pageKey).toBeFalsy();
+    const { lastId } = await listMotds({ pageSize: 8 });
+    expect(lastId).toBeFalsy();
   });
 
   it("returns empty array when no results", async () => {
@@ -81,7 +81,22 @@ describe("listMotds", () => {
     }
   });
 
-  it("doesn't exceed pageSize");
+  it("doesn't exceed pageSize", async () => {
+    // Create a bunch of dummy MOTDs
+    await Promise.all(
+      faker.helpers
+        .multiple(faker.hacker.phrase, { count: 256 })
+        .map(async (phrase) => createMotd(phrase)),
+    );
+
+    // Try out a bunch of different page sizes
+    await Promise.all(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(async (pageSize) => {
+        const results = await listMotds({ pageSize });
+        expect(results.items).toHaveLength(pageSize);
+      }),
+    );
+  });
 });
 
 describe("GET `/history`", () => {

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -32,7 +32,7 @@ describe("listMotds", () => {
   });
 });
 
-describe("PATCH `/:motdId`", () => {
+describe("GET `/history`", () => {
   let testApp: TestApp;
   beforeEach(async () => {
     testApp = new TestApp();

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -1,0 +1,55 @@
+import { faker } from "@faker-js/faker";
+import { MessageOfTheDay } from "@motd-ts/models";
+import mongoose from "mongoose";
+import supertest from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createMotd, fetchMotd, listMotds } from "../../src/services/motd.services";
+import TestApp from "../utils/testApp";
+
+describe("listMotds", () => {
+  let testApp: TestApp;
+  beforeEach(async () => {
+    testApp = new TestApp();
+    await testApp.setup();
+  });
+  afterEach(async () => {
+    await testApp.teardown();
+  });
+
+  //
+  //  Tests
+  //
+
+  it("excludes pageKey when no results", async () => {
+    const { pageKey } = await listMotds({ pageSize: 8 });
+    expect(pageKey).toBeFalsy();
+  });
+
+  it("returns empty array when no results", async () => {
+    const { items } = await listMotds({ pageSize: 8 });
+    expect(items).toBeTruthy();
+    expect(items).toHaveLength(0);
+  });
+});
+
+describe("PATCH `/:motdId`", () => {
+  let testApp: TestApp;
+  beforeEach(async () => {
+    testApp = new TestApp();
+    await testApp.setup();
+  });
+  afterEach(async () => {
+    await testApp.teardown();
+  });
+
+  //
+  //  Tests
+  //
+
+  it("200 when no MOTDs");
+  it("200 when MOTDs exist");
+  it("200 when MOTDs exist and using lastPageKey");
+  it("400 when no malformed lastPageKey used");
+  it("returns results in descending order");
+  it("doesn't skip MOTDs");
+});

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -97,6 +97,32 @@ describe("listMotds", () => {
       }),
     );
   });
+
+  it("can't use negative pageSize", async () => {
+    // Create a bunch of dummy MOTDs
+    await Promise.all(
+      faker.helpers
+        .multiple(faker.hacker.phrase, { count: 16 })
+        .map(async (phrase) => createMotd(phrase)),
+    );
+
+    const results = await listMotds({ pageSize: -1 });
+    expect(results.lastId).toBeFalsy();
+    expect(results.items).toHaveLength(0);
+  });
+
+  it("can't use NaN pageSize", async () => {
+    // Create a bunch of dummy MOTDs
+    await Promise.all(
+      faker.helpers
+        .multiple(faker.hacker.phrase, { count: 16 })
+        .map(async (phrase) => createMotd(phrase)),
+    );
+
+    const results = await listMotds({ pageSize: NaN });
+    expect(results.lastId).toBeFalsy();
+    expect(results.items).toHaveLength(0);
+  });
 });
 
 describe("GET `/history`", () => {

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -30,6 +30,31 @@ describe("listMotds", () => {
     expect(items).toBeTruthy();
     expect(items).toHaveLength(0);
   });
+
+  it("doesn't skip MOTDs", async () => {
+    // Create a bunch of dummy MOTDs
+    const allMotds = await Promise.all(
+      faker.helpers
+        .multiple(faker.hacker.phrase, { count: 32 })
+        .map(async (phrase) => createMotd(phrase)),
+    );
+
+    // Paginate through the EVERYTHING, and collect results.
+    const motdsFoundFromListing: MessageOfTheDay[] = [];
+    let lastPageKey: number | undefined;
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const results = await listMotds({ pageSize: 8, lastPageKey });
+
+      results.items.forEach((item) => motdsFoundFromListing.push(item));
+      lastPageKey = results.pageKey;
+    } while (lastPageKey);
+
+    expect(motdsFoundFromListing).toHaveLength(allMotds.length);
+  });
+
+  it("returns results in descending order");
+  it("doesn't exceed pageSize");
 });
 
 describe("GET `/history`", () => {
@@ -50,6 +75,4 @@ describe("GET `/history`", () => {
   it("200 when MOTDs exist");
   it("200 when MOTDs exist and using lastPageKey");
   it("400 when no malformed lastPageKey used");
-  it("returns results in descending order");
-  it("doesn't skip MOTDs");
 });

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -41,16 +41,17 @@ describe("listMotds", () => {
 
     // Paginate through the EVERYTHING, and collect results.
     const motdsFoundFromListing: MessageOfTheDay[] = [];
-    let lastPageKey: number | undefined;
+    let lastId: string | undefined;
     do {
       // eslint-disable-next-line no-await-in-loop
-      const results = await listMotds({ pageSize: 8, lastPageKey });
+      const results = await listMotds({ pageSize: 8, previousLastId: lastId });
 
       results.items.forEach((item) => motdsFoundFromListing.push(item));
-      lastPageKey = results.pageKey;
-    } while (lastPageKey);
+      lastId = results.lastId;
+    } while (lastId);
 
     expect(motdsFoundFromListing).toHaveLength(allMotds.length);
+    expect(motdsFoundFromListing).toEqual(expect.arrayContaining(allMotds));
   });
 
   it("returns results in descending order");

--- a/apps/express-backend/src/controllers/motd.controllers.ts
+++ b/apps/express-backend/src/controllers/motd.controllers.ts
@@ -104,20 +104,20 @@ export const remove: RequestHandler = async (req, res) => {
 /**
  * Lists existing MOTDs, sorted by date in descending order. Results are paginated.
  *
- * @param req.query.lastPageKey OPTIONAL - The page key to start at, if paginating. This should be
- *   the value of `pageKey` from a previous call.
+ * @param req.query.previousLastId OPTIONAL - The page key to start at, if paginating. This should
+ *   be the value of `lastId` from a previous call.
  * @param req.query.pageSize OPTIONAL - The max number of entries per-page.
  */
 export const list: RequestHandler = async (req, res) => {
   console.log(`Trying to list MOTDs...`);
   const result = await listMotds({
-    lastPageKey: req.query.lastPageKey ? parseInt(req.query.lastPageKey as string, 10) : undefined,
+    previousLastId: req.query.previousLastId as string,
     pageSize: parseInt(req.query.pageSize as string, 10),
   });
 
   res
     .status(200)
     .contentType("json")
-    .send(JSON.stringify({ pageKey: result.pageKey, items: result.items }));
+    .send(JSON.stringify({ lastId: result.lastId, items: result.items }));
   console.log(`...Listed ${result.items.length} MOTDs`);
 };

--- a/apps/express-backend/src/services/motd.services.ts
+++ b/apps/express-backend/src/services/motd.services.ts
@@ -110,6 +110,8 @@ export async function listMotds(args: {
   previousLastId?: string | mongoose.Types.ObjectId;
   pageSize: number;
 }): Promise<{ lastId?: string; items: MessageOfTheDay[] }> {
+  if (args.pageSize <= 0 || Number.isNaN(args.pageSize)) return { items: [] };
+
   // Create the search query depending on if we have a starting page key
   const searchQuery: FilterQuery<MessageOfTheDay> = {};
   if (args.previousLastId) searchQuery._id = { $lt: args.previousLastId };

--- a/apps/express-backend/src/services/motd.services.ts
+++ b/apps/express-backend/src/services/motd.services.ts
@@ -120,7 +120,7 @@ export async function listMotds(args: {
 
   // Search for MOTDs, making sure to search in order and start/stop in a paginated way.
   const foundItems = (
-    await MessageOfTheDayModel.find(searchQuery).limit(args.pageSize).sort("-createdAt")
+    await MessageOfTheDayModel.find(searchQuery).limit(args.pageSize).sort("-createdAt _id")
   ).map((fullItem) => fullItem.toObject({ versionKey: false, flattenObjectIds: true }));
 
   // Calculate the lastPageKey of THIS REQUEST. The page key is just the createdAt date of the

--- a/apps/express-backend/src/services/motd.services.ts
+++ b/apps/express-backend/src/services/motd.services.ts
@@ -115,6 +115,9 @@ export async function listMotds(args: {
   if (args.previousLastId) searchQuery._id = { $lt: args.previousLastId };
 
   // Search for MOTDs, making sure to search in order and start/stop in a paginated way.
+  // We don't sort by createdAt because it's possible for documents to have the same timestamp,
+  // which screws up paginating. Instead we rely on ObjectIds property of being ORDERED & unique to
+  // determine how to progress a cursor through the DB.
   const foundItems = (
     await MessageOfTheDayModel.find(searchQuery).limit(args.pageSize).sort("-_id")
   ).map((fullItem) => fullItem.toObject({ versionKey: false, flattenObjectIds: true }));

--- a/apps/express-backend/src/services/motd.services.ts
+++ b/apps/express-backend/src/services/motd.services.ts
@@ -119,11 +119,9 @@ export async function listMotds(args: {
   }
 
   // Search for MOTDs, making sure to search in order and start/stop in a paginated way.
-  const foundItems = await MessageOfTheDayModel.find(searchQuery)
-    .limit(args.pageSize)
-    .sort("-createdAt")
-    .select("-__v")
-    .lean();
+  const foundItems = (
+    await MessageOfTheDayModel.find(searchQuery).limit(args.pageSize).sort("-createdAt")
+  ).map((fullItem) => fullItem.toObject({ versionKey: false, flattenObjectIds: true }));
 
   // Calculate the lastPageKey of THIS REQUEST. The page key is just the createdAt date of the
   // last processed document, encoded as an integer.

--- a/apps/express-backend/src/services/motd.services.ts
+++ b/apps/express-backend/src/services/motd.services.ts
@@ -112,11 +112,11 @@ export async function listMotds(args: {
 }): Promise<{ lastId?: string; items: MessageOfTheDay[] }> {
   // Create the search query depending on if we have a starting page key
   const searchQuery: FilterQuery<MessageOfTheDay> = {};
-  if (args.previousLastId) searchQuery._id = { $gt: args.previousLastId };
+  if (args.previousLastId) searchQuery._id = { $lt: args.previousLastId };
 
   // Search for MOTDs, making sure to search in order and start/stop in a paginated way.
   const foundItems = (
-    await MessageOfTheDayModel.find(searchQuery).limit(args.pageSize).sort("_id")
+    await MessageOfTheDayModel.find(searchQuery).limit(args.pageSize).sort("-_id")
   ).map((fullItem) => fullItem.toObject({ versionKey: false, flattenObjectIds: true }));
 
   return {

--- a/openapi.yml
+++ b/openapi.yml
@@ -135,12 +135,13 @@ paths:
       description: Get a list of previous message of the days, sorted by newest to oldest. Results are paginated.
       parameters:
         - in: query
-          name: lastPageKey
-          description: If paginating, the value of the `pageKey` from the previous request.
+          name: previousLastId
+          description: If paginating, the value of the `lastId` from the previous request.
           required: false
           schema:
-            type: integer
-            example: 1704829257257
+            type: string
+            format: mongo-objectid
+            example: fMW0PcHRJGUtUnadq4mvy
         - in: query
           name: pageSize
           description: If paginating, the max number of entries per-page.
@@ -152,15 +153,16 @@ paths:
             default: 8
       responses:
         "200":
-          description: A list of MOTDs (after `lastPageKey`, if provided)
+          description: A list of MOTDs (after `previousLastId`, if provided)
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  pageKey:
-                    type: integer
-                    example: 1704829257257
+                  lastId:
+                    type: string
+                    format: mongo-objectid
+                    example: fMW0PcHRJGUtUnadq4mvy
                   items:
                     type: array
                     items:

--- a/openapi.yml
+++ b/openapi.yml
@@ -168,7 +168,7 @@ paths:
                     items:
                       $ref: "#/components/schemas/MOTD"
         "400":
-          description: Malformed `lastPageKey`.
+          description: Malformed `previousLastId` or `pageSize`.
 
 components:
   schemas:


### PR DESCRIPTION
Implements the first draft of MOTD Listing unit tests, revises the OpenAPI spec to address oversights, and patches bugs found from testing.  Additionally, this fixes a major bug where listing would skip documents if they had the same createdAt value.

This tests the following business logic:
- `listMotds`

This tests the following endpoints:
- GET `/history`