### PR TITLE
Bugfix: MongoDB Memory Server install before tests

### DIFF
--- a/apps/express-backend/__tests__/globalSetup.ts
+++ b/apps/express-backend/__tests__/globalSetup.ts
@@ -1,0 +1,7 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+export default async function globalSetup() {
+  // Spin up then spindown so that we force the memory server binaries to get downloaded
+  const dbInMemory = await MongoMemoryServer.create();
+  await dbInMemory.stop();
+}

--- a/apps/express-backend/package.json
+++ b/apps/express-backend/package.json
@@ -2,6 +2,7 @@
   "name": "@motd-ts/express-backend",
   "license": "BOBBO-NET Friendly MIT License",
   "private": "true",
+  "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "dev:up": "docker compose -f compose-local.yaml up -d --build --remove-orphans",

--- a/apps/express-backend/tsconfig.json
+++ b/apps/express-backend/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["vitest.config.ts"]
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/apps/express-backend/tsconfig.json
+++ b/apps/express-backend/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "include": ["vitest.config.ts"]
 }

--- a/apps/express-backend/tsconfig.node.json
+++ b/apps/express-backend/tsconfig.node.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": ["vitest.config.ts"]
+}

--- a/apps/express-backend/vitest.config.ts
+++ b/apps/express-backend/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+/* eslint-disable import/no-extraneous-dependencies */
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globalSetup: "__tests__/globalSetup.ts",
+  },
+});

--- a/apps/express-backend/vitest.config.ts
+++ b/apps/express-backend/vitest.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 /* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig } from "vitest/config";
 


### PR DESCRIPTION
This PR fixes a bug where the db memory server wouldn't install before tests - resulting in a possible case where every test would time out trying to download it's binaries.