### PR TITLE
Backend Auth Support

### DIFF
--- a/apps/express-backend/__tests__/motd/createMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/createMotd.test.ts
@@ -51,7 +51,10 @@ describe("POST `/`", () => {
 
   it("200 when given real data", async () => {
     const message = faker.hacker.phrase();
-    const response = await testApp.api.createMotd().send({ message }).expect(200);
+    const response = await testApp.api
+      .createMotd({ token: testApp.jwt.fake() })
+      .send({ message })
+      .expect(200);
 
     const motd = response.body as MessageOfTheDay;
     expect(motd).toBeTruthy();

--- a/apps/express-backend/__tests__/motd/createMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/createMotd.test.ts
@@ -52,7 +52,7 @@ describe("POST `/`", () => {
   it("200 when given real data", async () => {
     const message = faker.hacker.phrase();
     const response = await testApp.api
-      .createMotd({ token: testApp.jwt.real() })
+      .createMotd({ token: testApp.jwt.real("/motd") })
       .send({ message })
       .expect(200);
 
@@ -78,7 +78,7 @@ describe("POST `/`", () => {
   });
 
   it("415 when given no data", async () => {
-    const response = await testApp.api.createMotd({ token: testApp.jwt.real() }).expect(415);
+    const response = await testApp.api.createMotd({ token: testApp.jwt.real("/motd") }).expect(415);
 
     const motd = response.body as MessageOfTheDay;
     expect(motd._id).toBeFalsy();
@@ -87,7 +87,7 @@ describe("POST `/`", () => {
   it("400 when given empty message", async () => {
     const message = "";
     const response = await testApp.api
-      .createMotd({ token: testApp.jwt.real() })
+      .createMotd({ token: testApp.jwt.real("/motd") })
       .send({ message })
       .expect(400);
 

--- a/apps/express-backend/__tests__/motd/createMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/createMotd.test.ts
@@ -51,8 +51,7 @@ describe("POST `/`", () => {
 
   it("200 when given real data", async () => {
     const message = faker.hacker.phrase();
-    const response = await testApp.api.createMotd().send({ message });
-    expect(response.statusCode).toEqual(200);
+    const response = await testApp.api.createMotd().send({ message }).expect(200);
 
     const motd = response.body as MessageOfTheDay;
     expect(motd).toBeTruthy();
@@ -76,8 +75,7 @@ describe("POST `/`", () => {
   });
 
   it("415 when given no data", async () => {
-    const response = await testApp.api.createMotd({ token: testApp.jwt.real() });
-    expect(response.statusCode).toEqual(415);
+    const response = await testApp.api.createMotd({ token: testApp.jwt.real() }).expect(415);
 
     const motd = response.body as MessageOfTheDay;
     expect(motd._id).toBeFalsy();
@@ -85,8 +83,10 @@ describe("POST `/`", () => {
 
   it("400 when given empty message", async () => {
     const message = "";
-    const response = await testApp.api.createMotd({ token: testApp.jwt.real() }).send({ message });
-    expect(response.statusCode).toEqual(400);
+    const response = await testApp.api
+      .createMotd({ token: testApp.jwt.real() })
+      .send({ message })
+      .expect(400);
 
     const motd = response.body as MessageOfTheDay;
     expect(motd._id).toBeFalsy();

--- a/apps/express-backend/__tests__/motd/createMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/createMotd.test.ts
@@ -73,7 +73,7 @@ describe("POST `/`", () => {
     expect(response.statusCode).toEqual(401);
 
     // With irrelevant token
-    response = await testApp.api.createMotd({ token: testApp.jwt.real() }).send({ message });
+    response = await testApp.api.createMotd({ token: testApp.jwt.fake() }).send({ message });
     expect(response.statusCode).toEqual(401);
   });
 

--- a/apps/express-backend/__tests__/motd/createMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/createMotd.test.ts
@@ -39,7 +39,7 @@ describe("POST `/`", () => {
   let testApp: TestApp;
   beforeAll(async () => {
     testApp = new TestApp();
-    await testApp.setup();
+    await testApp.setup({ defaultAudience: "/motd" });
   });
   afterAll(async () => {
     await testApp.teardown();
@@ -51,10 +51,8 @@ describe("POST `/`", () => {
 
   it("200 when given real data", async () => {
     const message = faker.hacker.phrase();
-    const response = await testApp.api
-      .createMotd({ token: testApp.jwt.real("/motd") })
-      .send({ message })
-      .expect(200);
+    const token = testApp.jwt({ is: "valid", permissions: ["motd:create"] });
+    const response = await testApp.api.createMotd({ token }).send({ message }).expect(200);
 
     const motd = response.body as MessageOfTheDay;
     expect(motd).toBeTruthy();
@@ -69,29 +67,37 @@ describe("POST `/`", () => {
 
   it("401 when no auth token", async () => {
     const message = faker.hacker.phrase();
-    await testApp.api.createMotd({ token: undefined }).send({ message }).expect(401);
+    const token = undefined;
+    await testApp.api.createMotd({ token }).send({ message }).expect(401);
   });
 
-  it("401 when fake auth token", async () => {
+  it("401 when unsigned auth token", async () => {
     const message = faker.hacker.phrase();
-    await testApp.api.createMotd({ token: testApp.jwt.fake() }).send({ message }).expect(401);
+    const token = testApp.jwt({ is: "unsigned", permissions: ["motd:create"] });
+    await testApp.api.createMotd({ token }).send({ message }).expect(401);
+  });
+
+  it("401 when badly signed auth token", async () => {
+    const message = faker.hacker.phrase();
+    const token = testApp.jwt({ is: "badlySigned", permissions: ["motd:create"] });
+    await testApp.api.createMotd({ token }).send({ message }).expect(401);
+  });
+
+  it("401 when missing permissions", async () => {
+    const message = faker.hacker.phrase();
+    const token = testApp.jwt({ is: "valid", permissions: ["motd:somethingElse"] });
+    await testApp.api.createMotd({ token }).send({ message }).expect(401);
   });
 
   it("415 when given no data", async () => {
-    const response = await testApp.api.createMotd({ token: testApp.jwt.real("/motd") }).expect(415);
-
-    const motd = response.body as MessageOfTheDay;
-    expect(motd._id).toBeFalsy();
+    const token = testApp.jwt({ is: "valid", permissions: ["motd:create"] });
+    await testApp.api.createMotd({ token }).expect(415);
   });
 
   it("400 when given empty message", async () => {
     const message = "";
-    const response = await testApp.api
-      .createMotd({ token: testApp.jwt.real("/motd") })
-      .send({ message })
-      .expect(400);
-
-    const motd = response.body as MessageOfTheDay;
-    expect(motd._id).toBeFalsy();
+    const token = testApp.jwt({ is: "valid", permissions: ["motd:create"] });
+    const response = await testApp.api.createMotd({ token }).send({ message }).expect(400);
+    expect((response.body as MessageOfTheDay)._id).toBeFalsy();
   });
 });

--- a/apps/express-backend/__tests__/motd/createMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/createMotd.test.ts
@@ -52,7 +52,7 @@ describe("POST `/`", () => {
   it("200 when given real data", async () => {
     const message = faker.hacker.phrase();
     const response = await testApp.api
-      .createMotd({ token: testApp.jwt.fake() })
+      .createMotd({ token: testApp.jwt.real() })
       .send({ message })
       .expect(200);
 

--- a/apps/express-backend/__tests__/motd/createMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/createMotd.test.ts
@@ -65,16 +65,14 @@ describe("POST `/`", () => {
     expect(foundMotd).toBeTruthy();
   });
 
-  it("401 when bad auth token", async () => {
+  it("401 when no auth token", async () => {
     const message = faker.hacker.phrase();
+    await testApp.api.createMotd({ token: undefined }).send({ message }).expect(401);
+  });
 
-    // With no token
-    let response = await testApp.api.createMotd({ token: undefined }).send({ message });
-    expect(response.statusCode).toEqual(401);
-
-    // With irrelevant token
-    response = await testApp.api.createMotd({ token: testApp.jwt.fake() }).send({ message });
-    expect(response.statusCode).toEqual(401);
+  it("401 when fake auth token", async () => {
+    const message = faker.hacker.phrase();
+    await testApp.api.createMotd({ token: testApp.jwt.fake() }).send({ message }).expect(401);
   });
 
   it("415 when given no data", async () => {

--- a/apps/express-backend/__tests__/motd/fetchLatestMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/fetchLatestMotd.test.ts
@@ -46,7 +46,7 @@ describe("GET `/`", () => {
   let testApp: TestApp;
   beforeEach(async () => {
     testApp = new TestApp();
-    await testApp.setup();
+    await testApp.setup({ defaultAudience: "/motd" });
   });
   afterEach(async () => {
     await testApp.teardown();

--- a/apps/express-backend/__tests__/motd/fetchLatestMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/fetchLatestMotd.test.ts
@@ -1,6 +1,5 @@
 import { faker } from "@faker-js/faker";
 import { MessageOfTheDay } from "@motd-ts/models";
-import supertest from "supertest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createMotd, fetchLatestMotd } from "../../src/services/motd.services";
 import TestApp from "../utils/testApp";
@@ -59,7 +58,7 @@ describe("GET `/`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    const response = await supertest(testApp.server).get("/");
+    const response = await testApp.api.getLatestMotd();
     expect(response.statusCode).toEqual(200);
 
     const transformedMotd = JSON.parse(JSON.stringify(motd)) as MessageOfTheDay;
@@ -71,7 +70,7 @@ describe("GET `/`", () => {
   });
 
   it("404 when no MOTDs", async () => {
-    const response = await supertest(testApp.server).get("/");
+    const response = await testApp.api.getLatestMotd();
     expect(response.statusCode).toEqual(404);
   });
 });

--- a/apps/express-backend/__tests__/motd/fetchLatestMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/fetchLatestMotd.test.ts
@@ -58,8 +58,7 @@ describe("GET `/`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    const response = await testApp.api.getLatestMotd();
-    expect(response.statusCode).toEqual(200);
+    const response = await testApp.api.getLatestMotd().expect(200);
 
     const transformedMotd = JSON.parse(JSON.stringify(motd)) as MessageOfTheDay;
     const foundMotd: MessageOfTheDay = response.body;
@@ -70,7 +69,6 @@ describe("GET `/`", () => {
   });
 
   it("404 when no MOTDs", async () => {
-    const response = await testApp.api.getLatestMotd();
-    expect(response.statusCode).toEqual(404);
+    await testApp.api.getLatestMotd().expect(404);
   });
 });

--- a/apps/express-backend/__tests__/motd/fetchMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/fetchMotd.test.ts
@@ -53,7 +53,7 @@ describe("GET `/:motdId`", () => {
   let testApp: TestApp;
   beforeAll(async () => {
     testApp = new TestApp();
-    await testApp.setup();
+    await testApp.setup({ defaultAudience: "/motd" });
   });
   afterAll(async () => {
     await testApp.teardown();

--- a/apps/express-backend/__tests__/motd/fetchMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/fetchMotd.test.ts
@@ -64,16 +64,16 @@ describe("GET `/:motdId`", () => {
   //
 
   it("400 when invalid ID used", async () => {
-    const response = await testApp.api.getMotd("INVALIDID");
-    expect(response.statusCode).toEqual(400);
+    const response = await testApp.api.getMotd("INVALIDID").expect(400);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
   });
 
   it("404 when non-existing ObjectId used", async () => {
-    const response = await testApp.api.getMotd(new mongoose.Types.ObjectId().toString());
-    expect(response.statusCode).toEqual(404);
+    const response = await testApp.api
+      .getMotd(new mongoose.Types.ObjectId().toString())
+      .expect(404);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
@@ -81,8 +81,7 @@ describe("GET `/:motdId`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    const response = await testApp.api.getMotd(motd?._id!);
-    expect(response.statusCode).toEqual(200);
+    const response = await testApp.api.getMotd(motd?._id!).expect(200);
 
     const transformedMotd = JSON.parse(JSON.stringify(motd)) as MessageOfTheDay;
     const foundMotd: MessageOfTheDay = response.body;

--- a/apps/express-backend/__tests__/motd/fetchMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/fetchMotd.test.ts
@@ -1,7 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { MessageOfTheDay } from "@motd-ts/models";
 import mongoose from "mongoose";
-import supertest from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createMotd, fetchMotd } from "../../src/services/motd.services";
 import TestApp from "../utils/testApp";
@@ -65,7 +64,7 @@ describe("GET `/:motdId`", () => {
   //
 
   it("400 when invalid ID used", async () => {
-    const response = await supertest(testApp.server).get(`/BADIDTHINGY`);
+    const response = await testApp.api.getMotd("INVALIDID");
     expect(response.statusCode).toEqual(400);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -73,7 +72,7 @@ describe("GET `/:motdId`", () => {
   });
 
   it("404 when non-existing ObjectId used", async () => {
-    const response = await supertest(testApp.server).get(`/${new mongoose.Types.ObjectId()}`);
+    const response = await testApp.api.getMotd(new mongoose.Types.ObjectId().toString());
     expect(response.statusCode).toEqual(404);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -82,7 +81,7 @@ describe("GET `/:motdId`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    const response = await supertest(testApp.server).get(`/${motd?._id}`);
+    const response = await testApp.api.getMotd(motd?._id!);
     expect(response.statusCode).toEqual(200);
 
     const transformedMotd = JSON.parse(JSON.stringify(motd)) as MessageOfTheDay;

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -138,8 +138,7 @@ describe("GET `/history`", () => {
   //
 
   it("200 when no MOTDs", async () => {
-    const response = await testApp.api.listMotdHistory({});
-    expect(response.statusCode).toEqual(200);
+    const response = await testApp.api.listMotdHistory({}).expect(200);
     expect(response.body.lastId).toBeFalsy();
     expect(response.body.items).toHaveLength(0);
   });
@@ -153,8 +152,7 @@ describe("GET `/history`", () => {
         .map(async (phrase) => JSON.parse(JSON.stringify(await createMotd(phrase)))),
     );
 
-    const response = await testApp.api.listMotdHistory({});
-    expect(response.statusCode).toEqual(200);
+    const response = await testApp.api.listMotdHistory({}).expect(200);
     expect(response.body.lastId).toBeTruthy();
     expect(response.body.items.length).toBeGreaterThan(0);
     expect(allMotds).toEqual(expect.arrayContaining(response.body.items));
@@ -185,12 +183,10 @@ describe("GET `/history`", () => {
   });
 
   it("400 when malformed previousLastId used", async () => {
-    const response = await testApp.api.listMotdHistory({ previousLastId: "BADID" });
-    expect(response.statusCode).toEqual(400);
+    await testApp.api.listMotdHistory({ previousLastId: "BADID" }).expect(400);
   });
 
   it("400 when non-number used for pageSize", async () => {
-    const response = await testApp.api.listMotdHistory({ pageSize: "thisIsWrong" });
-    expect(response.statusCode).toEqual(400);
+    await testApp.api.listMotdHistory({ pageSize: "thisIsWrong" }).expect(400);
   });
 });

--- a/apps/express-backend/__tests__/motd/listMotds.test.ts
+++ b/apps/express-backend/__tests__/motd/listMotds.test.ts
@@ -127,7 +127,7 @@ describe("GET `/history`", () => {
   let testApp: TestApp;
   beforeEach(async () => {
     testApp = new TestApp();
-    await testApp.setup();
+    await testApp.setup({ defaultAudience: "/motd" });
   });
   afterEach(async () => {
     await testApp.teardown();

--- a/apps/express-backend/__tests__/motd/removeMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/removeMotd.test.ts
@@ -70,6 +70,12 @@ describe("DELETE `/:motdId`", () => {
     await testApp.api.deleteMotd(motd?._id!, { token }).expect(401);
   });
 
+  it("401 when missing permission", async () => {
+    const motd = await createMotd(faker.hacker.phrase());
+    const token = await testApp.jwt({ is: "valid", permissions: ["youDontHave:permission"] });
+    await testApp.api.deleteMotd(motd?._id!, { token }).expect(401);
+  });
+
   it("400 when invalid ID used", async () => {
     const token = testApp.jwt({ is: "valid", permissions: ["motd:delete"] });
     const response = await testApp.api.deleteMotd("BADID", { token }).expect(400);

--- a/apps/express-backend/__tests__/motd/removeMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/removeMotd.test.ts
@@ -59,18 +59,20 @@ describe("DELETE `/:motdId`", () => {
   //
 
   it("400 when invalid ID used", async () => {
-    const response = await testApp.api.deleteMotd("BADID", { token: testApp.jwt.real() });
-    expect(response.statusCode).toEqual(400);
+    const response = await testApp.api
+      .deleteMotd("BADID", { token: testApp.jwt.real() })
+      .expect(400);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
   });
 
   it("404 when non-existing ObjectId used", async () => {
-    const response = await testApp.api.deleteMotd(new mongoose.Types.ObjectId().toString(), {
-      token: testApp.jwt.real(),
-    });
-    expect(response.statusCode).toEqual(404);
+    const response = await testApp.api
+      .deleteMotd(new mongoose.Types.ObjectId().toString(), {
+        token: testApp.jwt.real(),
+      })
+      .expect(404);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
@@ -78,8 +80,7 @@ describe("DELETE `/:motdId`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    const response = await testApp.api.deleteMotd(motd?._id!, { token: testApp.jwt.real() });
-    expect(response.statusCode).toEqual(200);
+    await testApp.api.deleteMotd(motd?._id!, { token: testApp.jwt.real() }).expect(200);
 
     const foundMotd = await fetchMotd(motd?._id);
     expect(foundMotd).toBeFalsy();

--- a/apps/express-backend/__tests__/motd/removeMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/removeMotd.test.ts
@@ -59,7 +59,7 @@ describe("DELETE `/:motdId`", () => {
   //
 
   it("400 when invalid ID used", async () => {
-    const response = await testApp.api.deleteMotd("BADID");
+    const response = await testApp.api.deleteMotd("BADID", { token: testApp.jwt.real() });
     expect(response.statusCode).toEqual(400);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -67,7 +67,9 @@ describe("DELETE `/:motdId`", () => {
   });
 
   it("404 when non-existing ObjectId used", async () => {
-    const response = await testApp.api.deleteMotd(new mongoose.Types.ObjectId().toString());
+    const response = await testApp.api.deleteMotd(new mongoose.Types.ObjectId().toString(), {
+      token: testApp.jwt.real(),
+    });
     expect(response.statusCode).toEqual(404);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -76,7 +78,7 @@ describe("DELETE `/:motdId`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    const response = await testApp.api.deleteMotd(motd?._id!);
+    const response = await testApp.api.deleteMotd(motd?._id!, { token: testApp.jwt.real() });
     expect(response.statusCode).toEqual(200);
 
     const foundMotd = await fetchMotd(motd?._id);

--- a/apps/express-backend/__tests__/motd/removeMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/removeMotd.test.ts
@@ -58,6 +58,16 @@ describe("DELETE `/:motdId`", () => {
   //  Tests
   //
 
+  it("401 when no auth token", async () => {
+    const motd = await createMotd(faker.hacker.phrase());
+    await testApp.api.deleteMotd(motd?._id!, { token: undefined }).expect(401);
+  });
+
+  it("401 when fake auth token", async () => {
+    const motd = await createMotd(faker.hacker.phrase());
+    await testApp.api.deleteMotd(motd?._id!, { token: testApp.jwt.fake() }).expect(401);
+  });
+
   it("400 when invalid ID used", async () => {
     const response = await testApp.api
       .deleteMotd("BADID", { token: testApp.jwt.real("/motd") })

--- a/apps/express-backend/__tests__/motd/removeMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/removeMotd.test.ts
@@ -60,7 +60,7 @@ describe("DELETE `/:motdId`", () => {
 
   it("400 when invalid ID used", async () => {
     const response = await testApp.api
-      .deleteMotd("BADID", { token: testApp.jwt.real() })
+      .deleteMotd("BADID", { token: testApp.jwt.real("/motd") })
       .expect(400);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -70,7 +70,7 @@ describe("DELETE `/:motdId`", () => {
   it("404 when non-existing ObjectId used", async () => {
     const response = await testApp.api
       .deleteMotd(new mongoose.Types.ObjectId().toString(), {
-        token: testApp.jwt.real(),
+        token: testApp.jwt.real("/motd"),
       })
       .expect(404);
 
@@ -80,7 +80,7 @@ describe("DELETE `/:motdId`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    await testApp.api.deleteMotd(motd?._id!, { token: testApp.jwt.real() }).expect(200);
+    await testApp.api.deleteMotd(motd?._id!, { token: testApp.jwt.real("/motd") }).expect(200);
 
     const foundMotd = await fetchMotd(motd?._id);
     expect(foundMotd).toBeFalsy();

--- a/apps/express-backend/__tests__/motd/removeMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/removeMotd.test.ts
@@ -1,7 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { MessageOfTheDay } from "@motd-ts/models";
 import mongoose from "mongoose";
-import supertest from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createMotd, fetchMotd, removeMotd } from "../../src/services/motd.services";
 import TestApp from "../utils/testApp";
@@ -60,7 +59,7 @@ describe("DELETE `/:motdId`", () => {
   //
 
   it("400 when invalid ID used", async () => {
-    const response = await supertest(testApp.server).delete(`/BADID`);
+    const response = await testApp.api.deleteMotd("BADID");
     expect(response.statusCode).toEqual(400);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -68,7 +67,7 @@ describe("DELETE `/:motdId`", () => {
   });
 
   it("404 when non-existing ObjectId used", async () => {
-    const response = await supertest(testApp.server).delete(`/${new mongoose.Types.ObjectId()}`);
+    const response = await testApp.api.deleteMotd(new mongoose.Types.ObjectId().toString());
     expect(response.statusCode).toEqual(404);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -77,7 +76,7 @@ describe("DELETE `/:motdId`", () => {
 
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
-    const response = await supertest(testApp.server).delete(`/${motd?._id}`);
+    const response = await testApp.api.deleteMotd(motd?._id!);
     expect(response.statusCode).toEqual(200);
 
     const foundMotd = await fetchMotd(motd?._id);

--- a/apps/express-backend/__tests__/motd/updateMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/updateMotd.test.ts
@@ -88,18 +88,20 @@ describe("PATCH `/:motdId`", () => {
   //
 
   it("415 when invalid ID used and missing message", async () => {
-    const response = await testApp.api.updateMotd("BADID", { token: testApp.jwt.real() });
-    expect(response.statusCode).toEqual(415);
+    const response = await testApp.api
+      .updateMotd("BADID", { token: testApp.jwt.real() })
+      .expect(415);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
   });
 
   it("415 when non-existing ObjectId used and missing message", async () => {
-    const response = await testApp.api.updateMotd(new mongoose.Types.ObjectId().toString(), {
-      token: testApp.jwt.real(),
-    });
-    expect(response.statusCode).toEqual(415);
+    const response = await testApp.api
+      .updateMotd(new mongoose.Types.ObjectId().toString(), {
+        token: testApp.jwt.real(),
+      })
+      .expect(415);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
@@ -109,8 +111,8 @@ describe("PATCH `/:motdId`", () => {
     const message = faker.hacker.phrase();
     const response = await testApp.api
       .updateMotd("BADID", { token: testApp.jwt.real() })
-      .send({ message });
-    expect(response.statusCode).toEqual(400);
+      .send({ message })
+      .expect(400);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
@@ -120,8 +122,8 @@ describe("PATCH `/:motdId`", () => {
     const message = faker.hacker.phrase();
     const response = await testApp.api
       .updateMotd(new mongoose.Types.ObjectId().toString(), { token: testApp.jwt.real() })
-      .send({ message });
-    expect(response.statusCode).toEqual(404);
+      .send({ message })
+      .expect(404);
 
     const foundMotd: MessageOfTheDay = response.body;
     expect(foundMotd._id).toBeFalsy();
@@ -132,8 +134,8 @@ describe("PATCH `/:motdId`", () => {
     const newMessage = faker.company.catchPhrase();
     const response = await testApp.api
       .updateMotd(motd?._id!, { token: testApp.jwt.real() })
-      .send({ message: newMessage });
-    expect(response.statusCode).toEqual(200);
+      .send({ message: newMessage })
+      .expect(200);
 
     const transformedMotd = response.body as MessageOfTheDay;
     expect(transformedMotd._id).toEqual(motd?._id);

--- a/apps/express-backend/__tests__/motd/updateMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/updateMotd.test.ts
@@ -1,7 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { MessageOfTheDay } from "@motd-ts/models";
 import mongoose from "mongoose";
-import supertest from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createMotd, fetchMotd, updateMotd } from "../../src/services/motd.services";
 import TestApp from "../utils/testApp";
@@ -89,7 +88,7 @@ describe("PATCH `/:motdId`", () => {
   //
 
   it("415 when invalid ID used and missing message", async () => {
-    const response = await supertest(testApp.server).patch(`/BADID`);
+    const response = await testApp.api.updateMotd("BADID");
     expect(response.statusCode).toEqual(415);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -97,7 +96,7 @@ describe("PATCH `/:motdId`", () => {
   });
 
   it("415 when non-existing ObjectId used and missing message", async () => {
-    const response = await supertest(testApp.server).patch(`/${new mongoose.Types.ObjectId()}`);
+    const response = await testApp.api.updateMotd(new mongoose.Types.ObjectId().toString());
     expect(response.statusCode).toEqual(415);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -105,9 +104,8 @@ describe("PATCH `/:motdId`", () => {
   });
 
   it("400 when invalid ID used", async () => {
-    const response = await supertest(testApp.server)
-      .patch(`/BADID`)
-      .send({ message: faker.hacker.phrase() });
+    const message = faker.hacker.phrase();
+    const response = await testApp.api.updateMotd("BADID").send({ message });
     expect(response.statusCode).toEqual(400);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -115,9 +113,10 @@ describe("PATCH `/:motdId`", () => {
   });
 
   it("404 when non-existing ObjectId used", async () => {
-    const response = await supertest(testApp.server)
-      .patch(`/${new mongoose.Types.ObjectId()}`)
-      .send({ message: faker.hacker.phrase() });
+    const message = faker.hacker.phrase();
+    const response = await testApp.api
+      .updateMotd(new mongoose.Types.ObjectId().toString())
+      .send({ message });
     expect(response.statusCode).toEqual(404);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -127,9 +126,7 @@ describe("PATCH `/:motdId`", () => {
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
     const newMessage = faker.company.catchPhrase();
-    const response = await supertest(testApp.server)
-      .patch(`/${motd?._id}`)
-      .send({ message: newMessage });
+    const response = await testApp.api.updateMotd(motd?._id!).send({ message: newMessage });
     expect(response.statusCode).toEqual(200);
 
     const transformedMotd = response.body as MessageOfTheDay;

--- a/apps/express-backend/__tests__/motd/updateMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/updateMotd.test.ts
@@ -142,6 +142,13 @@ describe("PATCH `/:motdId`", () => {
     await testApp.api.updateMotd(motd?._id!, { token }).send({ message: newMessage }).expect(401);
   });
 
+  it("401 when missing permission", async () => {
+    const motd = await createMotd(faker.hacker.phrase());
+    const newMessage = faker.company.catchPhrase();
+    const token = await testApp.jwt({ is: "valid", permissions: ["someOther:permission"] });
+    await testApp.api.updateMotd(motd?._id!, { token }).send({ message: newMessage }).expect(401);
+  });
+
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
     const newMessage = faker.company.catchPhrase();

--- a/apps/express-backend/__tests__/motd/updateMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/updateMotd.test.ts
@@ -129,6 +129,24 @@ describe("PATCH `/:motdId`", () => {
     expect(foundMotd._id).toBeFalsy();
   });
 
+  it("401 when no auth token", async () => {
+    const motd = await createMotd(faker.hacker.phrase());
+    const newMessage = faker.company.catchPhrase();
+    await testApp.api
+      .updateMotd(motd?._id!, { token: undefined })
+      .send({ message: newMessage })
+      .expect(401);
+  });
+
+  it("401 when fake auth token", async () => {
+    const motd = await createMotd(faker.hacker.phrase());
+    const newMessage = faker.company.catchPhrase();
+    await testApp.api
+      .updateMotd(motd?._id!, { token: testApp.jwt.fake() })
+      .send({ message: newMessage })
+      .expect(401);
+  });
+
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
     const newMessage = faker.company.catchPhrase();

--- a/apps/express-backend/__tests__/motd/updateMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/updateMotd.test.ts
@@ -89,7 +89,7 @@ describe("PATCH `/:motdId`", () => {
 
   it("415 when invalid ID used and missing message", async () => {
     const response = await testApp.api
-      .updateMotd("BADID", { token: testApp.jwt.real() })
+      .updateMotd("BADID", { token: testApp.jwt.real("/motd") })
       .expect(415);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -99,7 +99,7 @@ describe("PATCH `/:motdId`", () => {
   it("415 when non-existing ObjectId used and missing message", async () => {
     const response = await testApp.api
       .updateMotd(new mongoose.Types.ObjectId().toString(), {
-        token: testApp.jwt.real(),
+        token: testApp.jwt.real("/motd"),
       })
       .expect(415);
 
@@ -110,7 +110,7 @@ describe("PATCH `/:motdId`", () => {
   it("400 when invalid ID used", async () => {
     const message = faker.hacker.phrase();
     const response = await testApp.api
-      .updateMotd("BADID", { token: testApp.jwt.real() })
+      .updateMotd("BADID", { token: testApp.jwt.real("/motd") })
       .send({ message })
       .expect(400);
 
@@ -121,7 +121,7 @@ describe("PATCH `/:motdId`", () => {
   it("404 when non-existing ObjectId used", async () => {
     const message = faker.hacker.phrase();
     const response = await testApp.api
-      .updateMotd(new mongoose.Types.ObjectId().toString(), { token: testApp.jwt.real() })
+      .updateMotd(new mongoose.Types.ObjectId().toString(), { token: testApp.jwt.real("/motd") })
       .send({ message })
       .expect(404);
 
@@ -133,7 +133,7 @@ describe("PATCH `/:motdId`", () => {
     const motd = await createMotd(faker.hacker.phrase());
     const newMessage = faker.company.catchPhrase();
     const response = await testApp.api
-      .updateMotd(motd?._id!, { token: testApp.jwt.real() })
+      .updateMotd(motd?._id!, { token: testApp.jwt.real("/motd") })
       .send({ message: newMessage })
       .expect(200);
 

--- a/apps/express-backend/__tests__/motd/updateMotd.test.ts
+++ b/apps/express-backend/__tests__/motd/updateMotd.test.ts
@@ -88,7 +88,7 @@ describe("PATCH `/:motdId`", () => {
   //
 
   it("415 when invalid ID used and missing message", async () => {
-    const response = await testApp.api.updateMotd("BADID");
+    const response = await testApp.api.updateMotd("BADID", { token: testApp.jwt.real() });
     expect(response.statusCode).toEqual(415);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -96,7 +96,9 @@ describe("PATCH `/:motdId`", () => {
   });
 
   it("415 when non-existing ObjectId used and missing message", async () => {
-    const response = await testApp.api.updateMotd(new mongoose.Types.ObjectId().toString());
+    const response = await testApp.api.updateMotd(new mongoose.Types.ObjectId().toString(), {
+      token: testApp.jwt.real(),
+    });
     expect(response.statusCode).toEqual(415);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -105,7 +107,9 @@ describe("PATCH `/:motdId`", () => {
 
   it("400 when invalid ID used", async () => {
     const message = faker.hacker.phrase();
-    const response = await testApp.api.updateMotd("BADID").send({ message });
+    const response = await testApp.api
+      .updateMotd("BADID", { token: testApp.jwt.real() })
+      .send({ message });
     expect(response.statusCode).toEqual(400);
 
     const foundMotd: MessageOfTheDay = response.body;
@@ -115,7 +119,7 @@ describe("PATCH `/:motdId`", () => {
   it("404 when non-existing ObjectId used", async () => {
     const message = faker.hacker.phrase();
     const response = await testApp.api
-      .updateMotd(new mongoose.Types.ObjectId().toString())
+      .updateMotd(new mongoose.Types.ObjectId().toString(), { token: testApp.jwt.real() })
       .send({ message });
     expect(response.statusCode).toEqual(404);
 
@@ -126,7 +130,9 @@ describe("PATCH `/:motdId`", () => {
   it("200 when MOTD exists", async () => {
     const motd = await createMotd(faker.hacker.phrase());
     const newMessage = faker.company.catchPhrase();
-    const response = await testApp.api.updateMotd(motd?._id!).send({ message: newMessage });
+    const response = await testApp.api
+      .updateMotd(motd?._id!, { token: testApp.jwt.real() })
+      .send({ message: newMessage });
     expect(response.statusCode).toEqual(200);
 
     const transformedMotd = response.body as MessageOfTheDay;

--- a/apps/express-backend/__tests__/utils/testApi.ts
+++ b/apps/express-backend/__tests__/utils/testApi.ts
@@ -63,7 +63,7 @@ export default class TestApi {
    */
   private request(method: string, endpoint: string, options?: RequestOptions): Test {
     const req: Test = supertest(this.app)[method](endpoint);
-    if (options?.token) req.set("Authorization", `Bearer: ${options.token}`);
+    if (options?.token) req.set("Authorization", `Bearer ${options.token}`);
     return req;
   }
 }

--- a/apps/express-backend/__tests__/utils/testApi.ts
+++ b/apps/express-backend/__tests__/utils/testApi.ts
@@ -24,30 +24,30 @@ export default class TestApi {
   //
 
   public getLatestMotd(options?: RequestOptions) {
-    return this.request("GET", "/", options);
+    return this.request("get", "/", options);
   }
 
   public createMotd(options?: RequestOptions) {
-    return this.request("POST", "/", options);
+    return this.request("post", "/", options);
   }
 
   public getMotd(id: string, options?: RequestOptions) {
-    return this.request("GET", `/${id}`, options);
+    return this.request("get", `/${id}`, options);
   }
 
   public updateMotd(id: string, options?: RequestOptions) {
-    return this.request("PATCH", `/${id}`, options);
+    return this.request("patch", `/${id}`, options);
   }
 
   public deleteMotd(id: string, options?: RequestOptions) {
-    return this.request("DELETE", `/${id}`, options);
+    return this.request("delete", `/${id}`, options);
   }
 
   public listMotdHistory(
     params: { previousLastId?: string; pageSize?: string },
     options?: RequestOptions,
   ) {
-    return this.request("GET", "/history", options).query(params);
+    return this.request("get", "/history", options).query(params);
   }
 
   //
@@ -63,7 +63,7 @@ export default class TestApi {
    */
   private request(method: string, endpoint: string, options?: RequestOptions): Test {
     const req: Test = supertest(this.app)[method](endpoint);
-    if (options?.token) req.set("Authorization: Bearer", options.token);
+    if (options?.token) req.set("Authorization", `Bearer: ${options.token}`);
     return req;
   }
 }

--- a/apps/express-backend/__tests__/utils/testApi.ts
+++ b/apps/express-backend/__tests__/utils/testApi.ts
@@ -1,0 +1,69 @@
+/**
+ * Thank you so so much to vegaByte @
+ * https://github.com/ladjs/supertest/issues/398#issuecomment-607463304 for this structure idea!
+ */
+
+import supertest, { Test } from "supertest";
+import { App } from "supertest/types";
+
+type RequestOptions = { token?: string };
+
+export default class TestApi {
+  private app: App;
+
+  //
+  //  Init
+  //
+
+  public setup(app: App) {
+    this.app = app;
+  }
+
+  //
+  //  Public Functions
+  //
+
+  public getLatestMotd(options?: RequestOptions) {
+    return this.request("GET", "/", options);
+  }
+
+  public createMotd(options?: RequestOptions) {
+    return this.request("POST", "/", options);
+  }
+
+  public getMotd(id: string, options?: RequestOptions) {
+    return this.request("GET", `/${id}`, options);
+  }
+
+  public updateMotd(id: string, options?: RequestOptions) {
+    return this.request("PATCH", `/${id}`, options);
+  }
+
+  public deleteMotd(id: string, options?: RequestOptions) {
+    return this.request("DELETE", `/${id}`, options);
+  }
+
+  public listMotdHistory(
+    params: { previousLastId?: string; pageSize?: string },
+    options?: RequestOptions,
+  ) {
+    return this.request("GET", "/history", options).query(params);
+  }
+
+  //
+  //  Private Functions
+  //
+
+  /**
+   * Create a supertest request configured for our application
+   *
+   * @param method The type of HTTP request to make.
+   * @param options Optional settings
+   * @returns A supertest request, unsent
+   */
+  private request(method: string, endpoint: string, options?: RequestOptions): Test {
+    const req: Test = supertest(this.app)[method](endpoint);
+    if (options?.token) req.set("Authorization: Bearer", options.token);
+    return req;
+  }
+}

--- a/apps/express-backend/__tests__/utils/testApi.ts
+++ b/apps/express-backend/__tests__/utils/testApi.ts
@@ -8,7 +8,12 @@ import { App } from "supertest/types";
 
 type RequestOptions = { token?: string };
 
+/**
+ * A utility class that helps with calling the actual endpoints of our backend app, using supertest!
+ * Intended to be used with `TestApp`.
+ */
 export default class TestApi {
+  /** The backend application that we'll call endpoints on */
   private app: App;
 
   //

--- a/apps/express-backend/__tests__/utils/testApp.ts
+++ b/apps/express-backend/__tests__/utils/testApp.ts
@@ -3,11 +3,17 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 import mongoose from "mongoose";
 import runApp from "../../src/app";
 import { API_SPEC_PATH } from "../../src/config/apiValidator.config";
+import TestApi from "./testApi";
+import TestJWT from "./testJWT";
 
 export default class TestApp {
   public server: http.Server;
 
   public mongod?: MongoMemoryServer;
+
+  public api: TestApi;
+
+  public jwt: TestJWT;
 
   public async setup() {
     // Create the in-memory test DB
@@ -19,6 +25,11 @@ export default class TestApp {
       apiSpecPath: API_SPEC_PATH,
     });
     this.server = startAppResults.httpServer;
+
+    this.api = new TestApi();
+    this.api.setup(this.server);
+
+    this.jwt = new TestJWT();
   }
 
   public async teardown() {

--- a/apps/express-backend/__tests__/utils/testApp.ts
+++ b/apps/express-backend/__tests__/utils/testApp.ts
@@ -31,7 +31,7 @@ export default class TestApp {
     this.api = new TestApi();
     this.api.setup(this.server);
 
-    this.jwt = new TestJWT();
+    this.jwt = new TestJWT(AUTH0_DOMAIN);
   }
 
   public async teardown() {

--- a/apps/express-backend/__tests__/utils/testApp.ts
+++ b/apps/express-backend/__tests__/utils/testApp.ts
@@ -7,15 +7,24 @@ import TestApi from "./testApi";
 import TestJWT from "./testJWT";
 import { AUTH0_DOMAIN } from "../../src/config/auth0.config";
 
+/**
+ * A utility class to help with testing our backend app. This wraps a bunch of things that sets up a
+ * valid runtime environment for the backend to operate while being tested.
+ */
 export default class TestApp {
+  /** The HTTP server instance backing our app */
   public server: http.Server;
 
+  /** The database emulated in memory for quick DB tests. */
   public mongod?: MongoMemoryServer;
 
+  /** QOL object that uses supertest to call actual endpoints. */
   public api: TestApi;
 
+  /** QOL object that allows for generating invalid JWTs, and fudging valid JWTs. */
   public jwt: TestJWT;
 
+  /** Spin up the backend app and configure the environment for testing. */
   public async setup() {
     // Create the in-memory test DB
     this.mongod = await MongoMemoryServer.create();
@@ -35,6 +44,7 @@ export default class TestApp {
     this.jwt.setup();
   }
 
+  /** Shutdown the backend app and un-configure the environment. */
   public async teardown() {
     this.jwt.teardown();
 

--- a/apps/express-backend/__tests__/utils/testApp.ts
+++ b/apps/express-backend/__tests__/utils/testApp.ts
@@ -5,6 +5,7 @@ import runApp from "../../src/app";
 import { API_SPEC_PATH } from "../../src/config/apiValidator.config";
 import TestApi from "./testApi";
 import TestJWT from "./testJWT";
+import { AUTH0_DOMAIN } from "../../src/config/auth0.config";
 
 export default class TestApp {
   public server: http.Server;
@@ -23,6 +24,7 @@ export default class TestApp {
     const startAppResults = await runApp({
       mongoDbUrl: this.mongod.getUri(),
       apiSpecPath: API_SPEC_PATH,
+      auth0Domain: AUTH0_DOMAIN,
     });
     this.server = startAppResults.httpServer;
 

--- a/apps/express-backend/__tests__/utils/testApp.ts
+++ b/apps/express-backend/__tests__/utils/testApp.ts
@@ -32,9 +32,12 @@ export default class TestApp {
     this.api.setup(this.server);
 
     this.jwt = new TestJWT(AUTH0_DOMAIN);
+    this.jwt.setup();
   }
 
   public async teardown() {
+    this.jwt.teardown();
+
     // Stop the backend
     await new Promise<void>((resolve, reject) => {
       this.server.close((err) => {

--- a/apps/express-backend/__tests__/utils/testJWT.ts
+++ b/apps/express-backend/__tests__/utils/testJWT.ts
@@ -4,6 +4,10 @@ import { JsonWebKey, createPublicKey, generateKeyPairSync } from "crypto";
 import jwt from "jsonwebtoken";
 import nock from "nock";
 
+/**
+ * A utility class to help with generating fake JWTs at runtime, and fudging JWTs that the backend
+ * considers to be real while being tested.
+ */
 export default class TestJWT {
   /** The passphrase to use when generating RSA keys. */
   readonly rsaPassphrase = "testPassphrase";

--- a/apps/express-backend/__tests__/utils/testJWT.ts
+++ b/apps/express-backend/__tests__/utils/testJWT.ts
@@ -1,0 +1,31 @@
+import { faker } from "@faker-js/faker";
+import jwt from "jsonwebtoken";
+
+export default class TestJWT {
+  /** A fake JWT to re-use. */
+  private cachedFakeJWT: string;
+
+  //
+  //  Public
+  //
+
+  /**
+   * Generates a fake JWT for testing purposes. The JWT is signed with it's own secret, but should
+   * NOT be valid to our API - meaning it can be used to ensure that endpoints don't accept just ANY
+   * JWT.
+   */
+  public fake(): string {
+    // If we don't have a fake JWT yet... GENERATE ONE.
+    if (!this.cachedFakeJWT) {
+      this.cachedFakeJWT = jwt.sign({ someMessage: faker.hacker.phrase() }, "secretOOOOO", {
+        audience: faker.hacker.noun(),
+      });
+    }
+    return this.cachedFakeJWT;
+  }
+
+  public real() {
+    throw new Error("TODO - implement JWT mocking");
+    return this.cachedFakeJWT;
+  }
+}

--- a/apps/express-backend/__tests__/utils/testJWT.ts
+++ b/apps/express-backend/__tests__/utils/testJWT.ts
@@ -1,9 +1,41 @@
+/** Thank you to https://carterbancroft.com/mocking-json-web-tokens-and-auth0/ for the reference! */
 import { faker } from "@faker-js/faker";
 import jwt from "jsonwebtoken";
+import { generateKeyPairSync, createPublicKey, createPrivateKey, JsonWebKey } from "crypto";
 
 export default class TestJWT {
+  /** The passphrase to use when generating RSA keys. */
+  readonly rsaPassphrase = "testPassphrase";
+
+  /** The domain that auth0 is using, for this app. */
+  private auth0Domain: string;
+
+  /** The private key to use when fudging "real" JWTs. */
+  private fudgedPrivateKey: string;
+
+  /** The public key to use when fudging "real" JWTs. */
+  private fudgedPublicKey: JsonWebKey;
+
   /** A fake JWT to re-use. */
   private cachedFakeJWT: string;
+
+  /**
+   * A cache of fudged JWTs to re-use that are considered "real". Key is the audience of the JWT,
+   * value is the encoded JWT itself.
+   */
+  private cachedJWTs: Map<string, string> = new Map<string, string>();
+
+  //
+  //  Init
+  //
+
+  constructor(auth0Domain: string) {
+    this.auth0Domain = auth0Domain;
+
+    const fudgedKeys = this.generateRSAKey();
+    this.fudgedPrivateKey = fudgedKeys.privateKey;
+    this.fudgedPublicKey = createPublicKey(fudgedKeys.publicKey).export({ format: "jwk" });
+  }
 
   //
   //  Public
@@ -24,8 +56,46 @@ export default class TestJWT {
     return this.cachedFakeJWT;
   }
 
-  public real() {
-    // throw new Error("TODO - implement JWT mocking");
-    return this.fake();
+  public real(audience: string) {
+    // If we don't have a "real" (fudged) JWT yet for this audience... GENERATE ONE.
+    if (!this.cachedJWTs.has(audience)) {
+      const payload = { nickname: faker.person.firstName() };
+      this.cachedJWTs.set(
+        audience,
+        jwt.sign(
+          payload,
+          { key: this.fudgedPrivateKey, passphrase: this.rsaPassphrase },
+          {
+            header: { kid: "0", alg: "RS256" },
+            algorithm: "RS256",
+            expiresIn: "1d",
+            issuer: `https://${this.auth0Domain}/`,
+            audience,
+          },
+        ),
+      );
+    }
+
+    return this.cachedJWTs.get(audience);
+  }
+
+  //
+  //  Private
+  //
+
+  private generateRSAKey() {
+    return generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem",
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-256-cbc",
+        passphrase: this.rsaPassphrase,
+      },
+    });
   }
 }

--- a/apps/express-backend/__tests__/utils/testJWT.ts
+++ b/apps/express-backend/__tests__/utils/testJWT.ts
@@ -4,6 +4,24 @@ import { JsonWebKey, createPublicKey, generateKeyPairSync } from "crypto";
 import jwt from "jsonwebtoken";
 import nock from "nock";
 
+export interface GenerateTestJwtConfig {
+  /**
+   * What type of JWT should we generate?
+   *
+   * - "valid": A JWT that while testing is considered valid and should be accepted by the backend.
+   * - "unsigned": A JWT that doesn't have a signature, which should get rejected by the backend.
+   * - "badlySigned": A JWT that is signed but NOT by our trusted sources, which should get rejected
+   *   by the backend.
+   */
+  is: "valid" | "unsigned" | "badlySigned";
+
+  /** The audience that this JWT is acting on. */
+  audience?: string;
+
+  /** The permissions that this JWT has. */
+  permissions?: string[];
+}
+
 /**
  * A utility class to help with generating fake JWTs at runtime, and fudging JWTs that the backend
  * considers to be real while being tested.
@@ -11,6 +29,9 @@ import nock from "nock";
 export default class TestJWT {
   /** The passphrase to use when generating RSA keys. */
   readonly rsaPassphrase = "testPassphrase";
+
+  /** OPTIONAL. A default audience value to use, when one is not provided. */
+  private defaultAudience?: string;
 
   /** The URL that auth0 is using, for this app. */
   private auth0Url: string;
@@ -24,22 +45,14 @@ export default class TestJWT {
   /** The currently running instance of nock, used to fudge JWT requests. */
   private nockInstance: nock.Interceptor;
 
-  /** A fake JWT to re-use. */
-  private cachedFakeJWT: string;
-
-  /**
-   * A cache of fudged JWTs to re-use that are considered "real". Key is the audience of the JWT,
-   * value is the encoded JWT itself.
-   */
-  private cachedJWTs: Map<string, string> = new Map<string, string>();
-
   //
   //  Init
   //
 
-  constructor(auth0Domain: string) {
-    this.auth0Url = `https://${auth0Domain}`;
+  constructor(config: { auth0Domain: string; defaultAudience?: string }) {
+    this.auth0Url = `https://${config.auth0Domain}`;
 
+    this.defaultAudience = config.defaultAudience;
     const fudgedKeys = this.generateRSAKey();
     this.fudgedPrivateKey = fudgedKeys.privateKey;
     this.fudgedPublicKey = createPublicKey(fudgedKeys.publicKey).export({ format: "jwk" });
@@ -58,47 +71,76 @@ export default class TestJWT {
   //  Public
   //
 
-  /**
-   * Generates a fake JWT for testing purposes. The JWT is signed with it's own secret, but should
-   * NOT be valid to our API - meaning it can be used to ensure that endpoints don't accept just ANY
-   * JWT.
-   */
-  public fake(): string {
-    // If we don't have a fake JWT yet... GENERATE ONE.
-    if (!this.cachedFakeJWT) {
-      this.cachedFakeJWT = jwt.sign({ someMessage: faker.hacker.phrase() }, "secretOOOOO", {
-        audience: faker.hacker.noun(),
-      });
-    }
-    return this.cachedFakeJWT;
-  }
+  /** Create a JWT to use for testing. */
+  public create(config: Partial<GenerateTestJwtConfig>): string {
+    // Assign defaults to the config so that it's no longer partial
+    const fullConfig: GenerateTestJwtConfig = {
+      is: "valid",
+      audience: this.defaultAudience,
+      ...config,
+    };
 
-  public real(audience: string) {
-    // If we don't have a "real" (fudged) JWT yet for this audience... GENERATE ONE.
-    if (!this.cachedJWTs.has(audience)) {
-      const payload = { nickname: faker.person.firstName() };
-      this.cachedJWTs.set(
-        audience,
-        jwt.sign(
-          payload,
-          { key: this.fudgedPrivateKey, passphrase: this.rsaPassphrase },
-          {
-            header: { kid: "0", alg: "RS256" },
-            algorithm: "RS256",
-            expiresIn: "1d",
-            issuer: `${this.auth0Url}/`,
-            audience,
-          },
-        ),
-      );
+    // Determine how to create the JWT based on the config.
+    switch (fullConfig.is) {
+      case "valid":
+        return this.createRealJwt(fullConfig);
+      case "badlySigned":
+        return this.createBadlySignedJwt(fullConfig);
+      case "unsigned":
+        return this.createUnsignedJwt(fullConfig);
+      default:
+        return "";
     }
-
-    return this.cachedJWTs.get(audience);
   }
 
   //
   //  Private
   //
+
+  public createRealJwt(config: GenerateTestJwtConfig) {
+    const { audience, permissions } = config;
+    const payload = { ...TestJWT.randomJwtPayload(), permissions };
+
+    return jwt.sign(
+      payload,
+      { key: this.fudgedPrivateKey, passphrase: this.rsaPassphrase },
+      {
+        header: { kid: "0", alg: "RS256" },
+        algorithm: "RS256",
+        expiresIn: "1d",
+        issuer: `${this.auth0Url}/`,
+        audience,
+      },
+    );
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public createBadlySignedJwt(config: GenerateTestJwtConfig): string {
+    const { audience, permissions } = config;
+    const payload = { ...TestJWT.randomJwtPayload(), permissions };
+
+    return jwt.sign(payload, "secretOOOOO", { audience });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public createUnsignedJwt(config: GenerateTestJwtConfig): string {
+    const { audience, permissions } = config;
+    const payload = { ...TestJWT.randomJwtPayload(), permissions };
+
+    return jwt.sign(payload, null, { audience, algorithm: "none" });
+  }
+
+  //
+  //  Private
+  //
+
+  private static randomJwtPayload() {
+    return {
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      nickname: faker.person.fullName(),
+    };
+  }
 
   private fudgeJWTResponse() {
     return {

--- a/apps/express-backend/__tests__/utils/testJWT.ts
+++ b/apps/express-backend/__tests__/utils/testJWT.ts
@@ -25,7 +25,7 @@ export default class TestJWT {
   }
 
   public real() {
-    throw new Error("TODO - implement JWT mocking");
-    return this.cachedFakeJWT;
+    // throw new Error("TODO - implement JWT mocking");
+    return this.fake();
   }
 }

--- a/apps/express-backend/package.json
+++ b/apps/express-backend/package.json
@@ -27,8 +27,10 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-jwt": "^8.4.1",
     "express-openapi-validator": "^5.1.6",
     "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.1.0",
     "mongoose": "^8.3.2"
   }
 }

--- a/apps/express-backend/package.json
+++ b/apps/express-backend/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
     "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/supertest": "^6.0.2",
     "@vitest/coverage-v8": "^1.5.0",
     "mongodb-memory-server": "^9.2.0",
@@ -27,6 +28,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-openapi-validator": "^5.1.6",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.3.2"
   }
 }

--- a/apps/express-backend/package.json
+++ b/apps/express-backend/package.json
@@ -31,6 +31,7 @@
     "express-openapi-validator": "^5.1.6",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",
-    "mongoose": "^8.3.2"
+    "mongoose": "^8.3.2",
+    "nock": "^13.5.4"
   }
 }

--- a/apps/express-backend/src/app.ts
+++ b/apps/express-backend/src/app.ts
@@ -50,8 +50,6 @@ async function runApp(
   // Handle any errors from express and wrap them as JSON
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err, req, res, next) => {
-    console.log(err);
-
     if (err.status) {
       // If we have a specific error status, just report that and wipe anything else to comply with
       // the API spec.

--- a/apps/express-backend/src/app.ts
+++ b/apps/express-backend/src/app.ts
@@ -3,12 +3,11 @@ import express from "express";
 import * as http from "http";
 import { connect as mongooseConnect } from "mongoose";
 import { AddressInfo } from "net";
+import { JwtMiddlewareConfig } from "./middleware/jwt.middleware.js";
 import createOpenApiValidatorMiddleware, {
   OpenApiValidatorMiddlewareConfig,
 } from "./middleware/openApiValidator.middleware.js";
 import createTransmissionRouter from "./routes/motd.routes.js";
-import { JwtMiddlewareConfig } from "./middleware/jwt.middleware.js";
-import { el } from "@faker-js/faker";
 
 /** Arguments required for the application to run */
 export type RunAppArguments = {

--- a/apps/express-backend/src/app.ts
+++ b/apps/express-backend/src/app.ts
@@ -50,6 +50,8 @@ async function runApp(
   // Handle any errors from express and wrap them as JSON
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err, req, res, next) => {
+    console.log(err);
+
     if (err.status) {
       // If we have a specific error status, just report that and wipe anything else to comply with
       // the API spec.

--- a/apps/express-backend/src/app.ts
+++ b/apps/express-backend/src/app.ts
@@ -3,20 +3,24 @@ import express from "express";
 import * as http from "http";
 import { connect as mongooseConnect } from "mongoose";
 import { AddressInfo } from "net";
-import createOpenApiValidatorMiddleware from "./middleware/openApiValidator.middleware.js";
-import transmissionRouter from "./routes/motd.routes.js";
+import createOpenApiValidatorMiddleware, {
+  OpenApiValidatorMiddlewareConfig,
+} from "./middleware/openApiValidator.middleware.js";
+import createTransmissionRouter from "./routes/motd.routes.js";
+import { JwtMiddlewareConfig } from "./middleware/jwt.middleware.js";
+import { el } from "@faker-js/faker";
 
 /** Arguments required for the application to run */
-export interface RunAppArguments {
+export type RunAppArguments = {
   /** The port to use for the HTTP server backing this app. */
   httpPort?: number;
 
   /** The URL to use when connecting to the database. */
   mongoDbUrl: string;
 
-  /** Where on disk to find the OpenAPI spec. */
-  apiSpecPath: string;
-}
+  /** The domain that auth0 is using, for this app. */
+  auth0Domain: JwtMiddlewareConfig["auth0Domain"];
+} & OpenApiValidatorMiddlewareConfig;
 
 /** Constructs and begins running the application. */
 async function runApp(
@@ -36,22 +40,28 @@ async function runApp(
 
   app.use(cors());
   app.use(express.json());
-  app.use(createOpenApiValidatorMiddleware(args.apiSpecPath));
+  app.use(createOpenApiValidatorMiddleware(args));
 
   //
   //  Routes
   //
 
-  app.use(transmissionRouter);
+  app.use(createTransmissionRouter({ audience: "/motd", auth0Domain: args.auth0Domain }));
 
   // Handle any errors from express and wrap them as JSON
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err, req, res, next) => {
-    // Report a catch-all for any errors.
-    res.status(err.status || 500).json({
-      message: err.message,
-      errors: err.errors,
-    });
+    if (err.status) {
+      // If we have a specific error status, just report that and wipe anything else to comply with
+      // the API spec.
+      res.status(err.status).send();
+    } else {
+      // Report a catch-all for any errors.
+      res.status(500).json({
+        message: err.message,
+        errors: err.errors,
+      });
+    }
   });
 
   //

--- a/apps/express-backend/src/config/auth0.config.ts
+++ b/apps/express-backend/src/config/auth0.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable import/prefer-default-export */
+import * as dotenv from "dotenv";
+
+//
+//  Defaults
+//
+
+const DEFAULT_AUTH0_DOMAIN = "dev-wduhl326w2kbi0k3.us.auth0.com";
+
+//
+//  Values
+//
+
+dotenv.config();
+
+/** The domain string representing the auth0 tenant to use with auth in this application. */
+export const AUTH0_DOMAIN: string = process.env.AUTH0_DOMAIN || DEFAULT_AUTH0_DOMAIN;

--- a/apps/express-backend/src/controllers/motd.controllers.ts
+++ b/apps/express-backend/src/controllers/motd.controllers.ts
@@ -7,6 +7,7 @@ import {
   removeMotd,
   updateMotd,
 } from "../services/motd.services";
+import hasPermissions from "../utils/hasPermissions";
 
 /**
  * Creates a new MOTD with a given message.
@@ -15,6 +16,12 @@ import {
  */
 export const create: RequestHandler = async (req, res) => {
   console.log(`Trying create MOTD...`);
+
+  // If we don't have permission, EXIT EARLY
+  if (!hasPermissions(req, ["motd:create"])) {
+    res.status(401).send();
+    return;
+  }
   const motd = await createMotd(req.body.message);
 
   // If the MOTD couldn't be created... EXIT EARLY!

--- a/apps/express-backend/src/controllers/motd.controllers.ts
+++ b/apps/express-backend/src/controllers/motd.controllers.ts
@@ -76,6 +76,12 @@ export const read: RequestHandler = async (req, res) => {
  */
 export const update: RequestHandler = async (req, res) => {
   console.log(`Trying update MOTD w/ id ${req.params.id}...`);
+
+  // If we don't have permission, EXIT EARLY
+  if (!hasPermissions(req, ["motd:update"])) {
+    res.status(401).send();
+    return;
+  }
   const motd = await updateMotd(req.params.id, req.body.message);
 
   // If there's no MOTD... EXIT EARLY!
@@ -95,6 +101,12 @@ export const update: RequestHandler = async (req, res) => {
  */
 export const remove: RequestHandler = async (req, res) => {
   console.log(`Trying remove MOTD w/ id ${req.params.id}...`);
+
+  // If we don't have permission, EXIT EARLY
+  if (!hasPermissions(req, ["motd:delete"])) {
+    res.status(401).send();
+    return;
+  }
   const result = await removeMotd(req.params.id);
 
   // If there's no MOTD... EXIT EARLY!

--- a/apps/express-backend/src/index.ts
+++ b/apps/express-backend/src/index.ts
@@ -1,11 +1,13 @@
 import runApp from "./app";
 import { API_SPEC_PATH } from "./config/apiValidator.config.js";
+import { AUTH0_DOMAIN } from "./config/auth0.config";
 import { HTTP_PORT } from "./config/http.config.js";
-import { MONGODB_URL } from "./config/mongoDb.config";
+import { MONGODB_URL } from "./config/mongoDb.config.js";
 
 // Actually run the application
 runApp({
   httpPort: HTTP_PORT,
   mongoDbUrl: MONGODB_URL,
   apiSpecPath: API_SPEC_PATH,
+  auth0Domain: AUTH0_DOMAIN,
 });

--- a/apps/express-backend/src/middleware/jwt.middleware.ts
+++ b/apps/express-backend/src/middleware/jwt.middleware.ts
@@ -1,0 +1,25 @@
+import { expressjwt } from "express-jwt";
+import JwksRsa, { GetVerificationKey } from "jwks-rsa";
+
+export interface JwtMiddlewareConfig {
+  /** The domain that auth0 is using, for this app. */
+  auth0Domain: string;
+
+  /** The audience required in the JWT for this middleware to pass. */
+  audience: string;
+}
+
+export default function create(config: JwtMiddlewareConfig): ReturnType<typeof expressjwt> {
+  return expressjwt({
+    audience: config.audience,
+    issuer: `https://${config.auth0Domain}/`,
+    algorithms: ["RS256"],
+
+    secret: JwksRsa.expressJwtSecret({
+      cache: true,
+      rateLimit: true,
+      jwksRequestsPerMinute: 10,
+      jwksUri: `https://${config.auth0Domain}/.well-known/jwks.json`,
+    }) as GetVerificationKey,
+  });
+}

--- a/apps/express-backend/src/middleware/openApiValidator.middleware.ts
+++ b/apps/express-backend/src/middleware/openApiValidator.middleware.ts
@@ -1,11 +1,13 @@
 import * as OpenAPIValidator from "express-openapi-validator";
 import mongoose from "mongoose";
 
-/**
- * @param apiSpecPath Where the OpenAPI yaml specification is on disk.
- * @returns An OpenAPIValidator middleware instance.
- */
-export default function create(apiSpecPath: string) {
+export interface OpenApiValidatorMiddlewareConfig {
+  /** Where the OpenAPI yaml specification is on disk. */
+  apiSpecPath: string;
+}
+
+/** @returns An OpenAPIValidator middleware instance. */
+export default function create({ apiSpecPath }: OpenApiValidatorMiddlewareConfig) {
   return OpenAPIValidator.middleware({
     apiSpec: apiSpecPath,
     validateRequests: {

--- a/apps/express-backend/src/routes/motd.routes.ts
+++ b/apps/express-backend/src/routes/motd.routes.ts
@@ -1,13 +1,16 @@
 import { Router } from "express";
 import * as controller from "../controllers/motd.controllers.js";
+import checkJwt, { JwtMiddlewareConfig } from "../middleware/jwt.middleware.js";
 
-const indexRouter: Router = Router();
+export default function create(args: JwtMiddlewareConfig): Router {
+  const router = Router();
 
-indexRouter.get("/", controller.readLatest);
-indexRouter.post("/", controller.create);
-indexRouter.get("/history", controller.list);
-indexRouter.get("/:id", controller.read);
-indexRouter.patch("/:id", controller.update);
-indexRouter.delete("/:id", controller.remove);
+  router.get("/", controller.readLatest);
+  router.post("/", [checkJwt(args), controller.create]);
+  router.get("/history", controller.list);
+  router.get("/:id", controller.read);
+  router.patch("/:id", checkJwt(args), controller.update);
+  router.delete("/:id", checkJwt(args), controller.remove);
 
-export default indexRouter;
+  return router;
+}

--- a/apps/express-backend/src/utils/getJwtFromRequest.ts
+++ b/apps/express-backend/src/utils/getJwtFromRequest.ts
@@ -1,0 +1,15 @@
+import { Request } from "express";
+
+/** Given a Request from Express, get the encoded JWT string from it's headers. */
+export default function getJwtFromRequest(req: Request): string | undefined {
+  try {
+    const headerValue: string | undefined = req.headers.authorization;
+    if (!headerValue) throw new Error("No Authorization header found");
+    if (!headerValue.includes("Bearer ")) throw new Error("Authorization header malformed");
+
+    return headerValue.split("Bearer ")[1];
+  } catch (e) {
+    // TODO - should we throw in the future?
+    return undefined;
+  }
+}

--- a/apps/express-backend/src/utils/hasPermissions.ts
+++ b/apps/express-backend/src/utils/hasPermissions.ts
@@ -1,0 +1,17 @@
+import { Request } from "express";
+import parseJwt from "./parseJwt";
+import getJwtFromRequest from "./getJwtFromRequest";
+
+/**
+ * Does the JWT in the given request have all of the given permissions? This does NOT verify the
+ * signature of the JWT.
+ */
+export default function hasPermissions(req: Request, requiredPermissions: string[]): boolean {
+  // Try to get the JWT from the request. If there isn't any, EXIT EARLY.
+  const jwt = parseJwt(getJwtFromRequest(req));
+  if (!jwt) return false;
+  if (!jwt.permissions) return false;
+
+  // Check to see if all of our required permissions are included in the JWT's permissions.
+  return requiredPermissions.every((permission) => jwt.permissions?.includes(permission));
+}

--- a/apps/express-backend/src/utils/parseJwt.ts
+++ b/apps/express-backend/src/utils/parseJwt.ts
@@ -1,0 +1,23 @@
+import jsonwebtoken from "jsonwebtoken";
+
+export type ParsedJwtPayload = jsonwebtoken.JwtPayload & { permissions?: string[] };
+
+/**
+ * Parses the contents of an encoded JWT string. This does NOT verify the JWT's signature, so make
+ * sure that this is only used on a trusted JWT (after a JWT middleware, for example).
+ *
+ * This always assumes that the JWT's payload is JSON.
+ */
+export default function parseJwt(jwtString: string | undefined): ParsedJwtPayload | undefined {
+  try {
+    if (!jwtString) throw new Error("No JWT string provided");
+
+    const jwt = jsonwebtoken.decode(jwtString, { complete: true, json: true });
+    if (!jwt) throw new Error("Failed to decode JWT string");
+
+    return jwt.payload as jsonwebtoken.JwtPayload;
+  } catch (e) {
+    // TODO - should we ever throw, here?
+    return undefined;
+  }
+}

--- a/apps/express-backend/vitest.config.ts
+++ b/apps/express-backend/vitest.config.ts
@@ -4,5 +4,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globalSetup: "__tests__/globalSetup.ts",
+    maxConcurrency: 2,
   },
 });

--- a/apps/react-frontend/appConfig.json
+++ b/apps/react-frontend/appConfig.json
@@ -1,4 +1,5 @@
 {
   "auth0Domain": "dev-wduhl326w2kbi0k3.us.auth0.com",
-  "auth0ClientId": "VI6xgABOsveiZcnTOsiRUtgVMcLcYXCh"
+  "auth0ClientId": "VI6xgABOsveiZcnTOsiRUtgVMcLcYXCh",
+  "auth0Audience": "/motd"
 }

--- a/apps/react-frontend/src/App.tsx
+++ b/apps/react-frontend/src/App.tsx
@@ -9,7 +9,7 @@ import HistoryPanel from "./features/history/HistoryPanel";
 import LatestMotdDisplay from "./features/motd/LatestMotdDisplay";
 import theme from "./theme";
 import AccountPanel from "./features/account/AccountPanel";
-import { auth0ClientId, auth0Domain } from "../appConfig.json";
+import { auth0ClientId, auth0Domain, auth0Audience } from "../appConfig.json";
 
 const queryClient = new QueryClient();
 
@@ -18,7 +18,10 @@ function App() {
     <Auth0Provider
       domain={auth0Domain}
       clientId={auth0ClientId}
-      authorizationParams={{ redirect_uri: window.location.origin }}
+      authorizationParams={{
+        redirect_uri: window.location.origin,
+        audience: auth0Audience,
+      }}
     >
       <QueryClientProvider client={queryClient}>
         <MantineProvider theme={theme} defaultColorScheme="light">

--- a/apps/react-frontend/src/api/motd.ts
+++ b/apps/react-frontend/src/api/motd.ts
@@ -6,7 +6,7 @@ const urls = {
   base: () => "http://localhost:30330",
   getLatest: () => `${urls.base()}/`,
   getHistory: () => `${urls.base()}/history`,
-  update: (id: string) => `${urls.base}/${id}`,
+  update: (id: string) => `${urls.base()}/${id}`,
   create: () => `${urls.base()}/`,
 };
 

--- a/apps/react-frontend/src/api/motd.ts
+++ b/apps/react-frontend/src/api/motd.ts
@@ -1,7 +1,14 @@
 import { MessageOfTheDay, inflateMessageOfTheDay } from "@motd-ts/models";
-import axios from "axios";
+import makeRequest from "../utils/makeRequest";
 
-const address: string = "http://localhost:30330";
+/** URL constructor functions. */
+const urls = {
+  base: () => "http://localhost:30330",
+  getLatest: () => `${urls.base()}/`,
+  getHistory: () => `${urls.base()}/history`,
+  update: (id: string) => `${urls.base}/${id}`,
+  create: () => `${urls.base()}/`,
+};
 
 /**
  * Get the latest known MOTD from the API.
@@ -9,7 +16,8 @@ const address: string = "http://localhost:30330";
  * @returns The latest MOTD as an inflated object. undefined if there are no MOTDs.
  */
 export async function getLatestMotd(): Promise<MessageOfTheDay | undefined> {
-  const response = await axios.get(`${address}/`);
+  const response = await makeRequest("GET", urls.getLatest());
+
   if (response.status !== 200) return undefined;
   return inflateMessageOfTheDay(response.data);
 }
@@ -23,8 +31,9 @@ export async function getMotdHistory({
   pageSize?: number;
 }): Promise<{ lastId?: string; items: MessageOfTheDay[] } | undefined> {
   // Request MOTD history from the backend. If there's an error, EXIT EARLY
-  const queryParams = { previousLastId, pageSize };
-  const response = await axios.get(`${address}/history`, { params: queryParams });
+  const response = await makeRequest("GET", urls.getHistory(), {
+    queryParams: { previousLastId, pageSize },
+  });
   if (response.status !== 200) return undefined;
 
   // Format our result data
@@ -55,17 +64,31 @@ export async function getAllMotdHistory(): Promise<MessageOfTheDay[]> {
 export async function updateMotd(
   id: string,
   newProps: { message?: string },
+  config: {
+    accessToken: string;
+  },
 ): Promise<MessageOfTheDay | undefined> {
-  const response = await axios.patch(`${address}/${id}`, newProps);
+  const response = await makeRequest("PATCH", urls.update(id), {
+    data: newProps,
+    authToken: config.accessToken,
+  });
+
   if (response.status !== 200) return undefined;
   return inflateMessageOfTheDay(response.data);
 }
 
 /** Create a new MOTD in the API. */
-export async function createMotd(properties: {
-  message: string;
-}): Promise<MessageOfTheDay | undefined> {
-  const response = await axios.post(`${address}`, properties);
+export async function createMotd(
+  newMotd: { message: string },
+  config: {
+    accessToken: string;
+  },
+): Promise<MessageOfTheDay | undefined> {
+  const response = await makeRequest("POST", urls.create(), {
+    data: newMotd,
+    authToken: config.accessToken,
+  });
+
   if (response.status !== 200) return undefined;
   return inflateMessageOfTheDay(response.data);
 }

--- a/apps/react-frontend/src/utils/makeRequest.ts
+++ b/apps/react-frontend/src/utils/makeRequest.ts
@@ -1,0 +1,68 @@
+import axios, { AxiosRequestConfig } from "axios";
+
+/**
+ * The possible types of HTTP request methods. See:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+ */
+export type RequestMethod =
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "CONNECT"
+  | "OPTIONS"
+  | "TRACE"
+  | "PATCH";
+
+/** Options for making an HTTP request. */
+export interface RequestOptions {
+  /**
+   * The data to include / serialize in the request body, if any. Automatically stringifies this
+   * into JSON.
+   */
+  data?: any;
+
+  /**
+   * The auth token to use for this request. Gets placed in the "Authorization" header and used like
+   * a JWT.
+   */
+  authToken?: string;
+
+  /**
+   * Should this throw an error when the response code is not 200?
+   *
+   * @default false
+   * @todo Make this TRUE by default.
+   */
+  throwWhenNotOk?: boolean;
+
+  /** Parameters to be serialized into the query-string of the request. */
+  queryParams?: { [key: string]: undefined | string | number };
+}
+
+/** A wrapper function to that makes HTTP requests. */
+export default async function makeRequest(
+  method: RequestMethod,
+  url: string,
+  options: RequestOptions = {},
+) {
+  // Get our options, making sure to assign defaults along the way.
+  const { data, authToken, throwWhenNotOk, queryParams } = { throwWhenNotOk: false, ...options };
+  const headers: AxiosRequestConfig["headers"] = {};
+
+  // If we should use auth, store our token in our request headers
+  if (authToken) {
+    if (authToken) headers.Authorization = `Bearer ${authToken}`;
+  }
+
+  // ACTUALLY MAKE the HTTP request
+  const response = await axios(url, { method, data, headers, params: queryParams });
+
+  // If we should throw when this is not 200, DO IT.
+  if (throwWhenNotOk && response.status !== 200) {
+    throw new Error(`makeRequest Error: ${response.status} - ${response.statusText}`);
+  }
+
+  return response;
+}

--- a/motd-api-ts.code-workspace
+++ b/motd-api-ts.code-workspace
@@ -23,5 +23,11 @@
       "**/*.less",
       "**/node_modules/@mantine/core/styles.css",
     ],
+    "[typescript]": {
+      "editor.rulers": [100],
+    },
+    "[typescriptreact]": {
+      "editor.rulers": [100],
+    },
   },
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -28,6 +28,8 @@ paths:
     post:
       summary: Create new MOTD
       description: Creates a new MOTD and returns information about it.
+      security:
+        - jwt: ["motd:create"]
       requestBody:
         description: Data for the new MOTD.
         required: true
@@ -47,10 +49,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MOTD"
-        "415":
-          description: Incorrect Content-Type.
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "400":
           description: Invalid arguments. Message must not be empty.
+        "415":
+          description: Incorrect Content-Type.
   /{id}:
     get:
       summary: Get specific MOTD
@@ -78,6 +82,8 @@ paths:
     patch:
       summary: Update specific MOTD
       description: Updates the message field of a specific message of the day.
+      security:
+        - jwt: ["motd:update"]
       parameters:
         - in: path
           name: id
@@ -106,6 +112,8 @@ paths:
                 $ref: "#/components/schemas/MOTD"
         "400":
           description: Malformatted ID provided.
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "404":
           description: No MOTD by that ID found.
         "415":
@@ -113,6 +121,8 @@ paths:
     delete:
       summary: Remove specific MOTD
       description: Removes a specific message of the day.
+      security:
+        - jwt: ["motd:delete"]
       parameters:
         - in: path
           name: id
@@ -127,6 +137,8 @@ paths:
           description: The MOTD with the matching ID was removed.
         "400":
           description: Malformatted ID provided.
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "404":
           description: No MOTD by that ID found.
   /history:
@@ -171,6 +183,14 @@ paths:
           description: Malformed `previousLastId` or `pageSize`.
 
 components:
+  securitySchemes:
+    jwt:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    UnauthorizedError:
+      description: Access token is missing or invalid.
   schemas:
     MOTD:
       description: An object representing some message of the day.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       mongoose:
         specifier: ^8.3.2
         version: 8.3.2(socks@2.8.3)
+      nock:
+        specifier: ^13.5.4
+        version: 13.5.4
     devDependencies:
       '@faker-js/faker':
         specifier: ^8.4.1
@@ -3618,6 +3621,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -4151,6 +4157,10 @@ packages:
     resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
     engines: {node: '>=12.0.0'}
 
+  nock@13.5.4:
+    resolution: {integrity: sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==}
+    engines: {node: '>= 10.13'}
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -4485,6 +4495,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  propagate@2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -9650,6 +9664,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -10390,6 +10406,14 @@ snapshots:
 
   nocache@3.0.4: {}
 
+  nock@13.5.4:
+    dependencies:
+      debug: 4.3.4
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   node-abort-controller@3.1.1: {}
 
   node-dir@0.1.17:
@@ -10714,6 +10738,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  propagate@2.0.1: {}
 
   proxy-addr@2.0.7:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,12 +66,18 @@ importers:
       express:
         specifier: ^4.19.2
         version: 4.19.2
+      express-jwt:
+        specifier: ^8.4.1
+        version: 8.4.1
       express-openapi-validator:
         specifier: ^5.1.6
         version: 5.1.6
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      jwks-rsa:
+        specifier: ^3.1.0
+        version: 3.1.0
       mongoose:
         specifier: ^8.3.2
         version: 8.3.2(socks@2.8.3)
@@ -2944,8 +2950,15 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  express-jwt@8.4.1:
+    resolution: {integrity: sha512-IZoZiDv2yZJAb3QrbaSATVtTCYT11OcqgFGoTN4iKVyN6NBkBkhtVIixww5fmakF0Upt5HfOxJuS6ZmJVeOtTQ==}
+    engines: {node: '>= 8.0.0'}
+
   express-openapi-validator@5.1.6:
     resolution: {integrity: sha512-CF24Pef5uThjdsCbjo1UP2mYx2YCkQl1HFoikCFFafFpZBCZ0YErD/RbqlcnKbKM9tMwXZsjAuuO84b2hmdF4g==}
+
+  express-unless@2.1.3:
+    resolution: {integrity: sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ==}
 
   express@4.19.2:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
@@ -3540,6 +3553,9 @@ packages:
   joi@17.13.0:
     resolution: {integrity: sha512-9qcrTyoBmFZRNHeVP4edKqIUEgFzq7MHvTNSDuHSqkpOPtiBkgNgcmTSqmiw1kw9tdKaiddvIDv/eCJDxmqWCA==}
 
+  jose@4.15.5:
+    resolution: {integrity: sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3625,6 +3641,10 @@ packages:
   jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
 
+  jwks-rsa@3.1.0:
+    resolution: {integrity: sha512-v7nqlfezb9YfHHzYII3ef2a2j1XnGeSE/bK3WfumaYCqONAIstJbrEGapz4kadScZzEt7zYCN7bucj8C0Mv/Rg==}
+    engines: {node: '>=14'}
+
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
@@ -3671,6 +3691,9 @@ packages:
   lilconfig@3.0.0:
     resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
     engines: {node: '>=14'}
+
+  limiter@1.1.5:
+    resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
 
   lint-staged@15.2.2:
     resolution: {integrity: sha512-TiTt93OPh1OZOsb5B7k96A/ATl2AjIZo+vnzFZ6oHK5FuTk63ByDtxGQpHm+kFETjEWqgkF95M8FRXKR/LEBcw==}
@@ -3759,12 +3782,18 @@ packages:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@4.0.2:
+    resolution: {integrity: sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lru-memoizer@2.2.0:
+    resolution: {integrity: sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4463,6 +4492,9 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pseudomap@1.0.2:
+    resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
   psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -5565,6 +5597,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@2.1.2:
+    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -8856,6 +8891,12 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  express-jwt@8.4.1:
+    dependencies:
+      '@types/jsonwebtoken': 9.0.6
+      express-unless: 2.1.3
+      jsonwebtoken: 9.0.2
+
   express-openapi-validator@5.1.6:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.1.2
@@ -8871,6 +8912,8 @@ snapshots:
       multer: 1.4.5-lts.1
       ono: 7.1.3
       path-to-regexp: 6.2.2
+
+  express-unless@2.1.3: {}
 
   express@4.19.2:
     dependencies:
@@ -9519,6 +9562,8 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
+  jose@4.15.5: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.0: {}
@@ -9641,6 +9686,17 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
+  jwks-rsa@3.1.0:
+    dependencies:
+      '@types/express': 4.17.21
+      '@types/jsonwebtoken': 9.0.6
+      debug: 4.3.4
+      jose: 4.15.5
+      limiter: 1.1.5
+      lru-memoizer: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   jws@3.2.2:
     dependencies:
       jwa: 1.4.1
@@ -9681,6 +9737,8 @@ snapshots:
       - supports-color
 
   lilconfig@3.0.0: {}
+
+  limiter@1.1.5: {}
 
   lint-staged@15.2.2:
     dependencies:
@@ -9779,6 +9837,11 @@ snapshots:
 
   lru-cache@10.2.0: {}
 
+  lru-cache@4.0.2:
+    dependencies:
+      pseudomap: 1.0.2
+      yallist: 2.1.2
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -9786,6 +9849,11 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lru-memoizer@2.2.0:
+    dependencies:
+      lodash.clonedeep: 4.5.0
+      lru-cache: 4.0.2
 
   lz-string@1.5.0: {}
 
@@ -10653,6 +10721,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  pseudomap@1.0.2: {}
 
   psl@1.9.0: {}
 
@@ -11839,6 +11909,8 @@ snapshots:
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
+
+  yallist@2.1.2: {}
 
   yallist@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       express-openapi-validator:
         specifier: ^5.1.6
         version: 5.1.6
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
       mongoose:
         specifier: ^8.3.2
         version: 8.3.2(socks@2.8.3)
@@ -79,6 +82,9 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
+      '@types/jsonwebtoken':
+        specifier: ^9.0.6
+        version: 9.0.6
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
Implements auth support into the backend via JWT expected to be provided in the frontend. The spec has been updated to reflect which endpoints require auth. Additionally, all backend tests have been updated to utilize & mock JWTs in a robust fashion. 