### PR TITLE
Frontend Dev Server Proxy

### DIFF
--- a/apps/react-frontend/src/api/motd.ts
+++ b/apps/react-frontend/src/api/motd.ts
@@ -3,7 +3,7 @@ import makeRequest from "../utils/makeRequest";
 
 /** URL constructor functions. */
 const urls = {
-  base: () => "http://localhost:30330",
+  base: () => "motd",
   getLatest: () => `${urls.base()}/`,
   getHistory: () => `${urls.base()}/history`,
   update: (id: string) => `${urls.base()}/${id}`,

--- a/apps/react-frontend/vite.config.ts
+++ b/apps/react-frontend/vite.config.ts
@@ -5,4 +5,16 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  server: {
+    proxy: {
+      /**
+       * Setup the frontend dev server so that it re-routes backend requests to our backend dev
+       * server.
+       */
+      "/motd": {
+        target: "http://localhost:30330",
+        rewrite: (path) => path.replace(/^\/motd/, ""),
+      },
+    },
+  },
 });


### PR DESCRIPTION
Reconfigures Vite to proxy backend requests when using the development server, rather than using the localhost URL directly in code.

This has been done in prep for deploying the site to production.