### PR TITLE
Fixed Frontend Tab Name

### DIFF
--- a/apps/react-frontend/index.html
+++ b/apps/react-frontend/index.html
@@ -10,7 +10,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>React Redux App</title>
+    <title>MOTD Example</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This fixes the tab title of the frontend app. Previously it was the default "React Redux App". Now it's "MOTD Example".